### PR TITLE
feat: implement update theme by slug functionality

### DIFF
--- a/src/application/services/SettingThemeService.ts
+++ b/src/application/services/SettingThemeService.ts
@@ -33,7 +33,7 @@ export class SettingThemeService implements ISettingThemeService {
     const content = await this.fillProductsIds(theme.content);
     return {
       id: theme.id,
-      name: theme.name,
+      name: theme.name || '',
       slug: theme.slug,
       content
     };
@@ -47,7 +47,7 @@ export class SettingThemeService implements ISettingThemeService {
     const content = await this.fillProductsIds(theme.content);
     return {
       id: theme.id,
-      name: theme.name,
+      name: theme.name || '',
       slug: theme.slug,
       content
     };
@@ -77,6 +77,34 @@ export class SettingThemeService implements ISettingThemeService {
     return {
       id: theme.id,
       name: theme.name,
+      slug: theme.slug,
+      content: theme.content
+    };
+  }
+
+  // async updateTheme(data: { name: string; content: any }): Promise<ISettingThemeResponse> {
+  //   const { name, content } = data;
+  //   const theme = await this.settingThemeRepository.updateTheme(name, content);
+  //   if (!theme) {
+  //     throw new Error(`Tema '${name}' no encontrado`);
+  //   }
+  //   return {
+  //     id: theme.id,
+  //     name: theme.name || '',
+  //     slug: theme.slug,
+  //     content: theme.content
+  //   };
+  // }
+
+  async updateThemeBySlug(data: { slug: string; name: string; content: any }): Promise<ISettingThemeResponse | null> {
+    const { slug, name, content } = data;
+    const theme = await this.settingThemeRepository.updateThemeBySlug(slug, name, content);
+    if (!theme) {
+      return null;
+    }
+    return {
+      id: theme.id,
+      name: theme.name || name,
       slug: theme.slug,
       content: theme.content
     };

--- a/src/domain/interfaces/ISettingThemeService.ts
+++ b/src/domain/interfaces/ISettingThemeService.ts
@@ -5,5 +5,6 @@ export interface ISettingThemeService {
   getThemeBySlug(slug: string): Promise<ISettingThemeResponse>;
   getAllThemes(): Promise<ISettingThemeListResponse>;
   saveTheme(themeData: ISettingThemeRequest): Promise<ISettingThemeResponse>;
+  updateThemeBySlug(data: { slug: string; name: string; content: any }): Promise<ISettingThemeResponse | null>;
   deleteTheme(name: string): Promise<boolean>;
 } 

--- a/src/infrastructure/repositories/SettingThemeRepository.ts
+++ b/src/infrastructure/repositories/SettingThemeRepository.ts
@@ -30,6 +30,32 @@ export class SettingThemeRepository {
     return theme;
   }
 
+  async updateThemeBySlug(slug: string, name: string, content: any): Promise<ISettingTheme | null> {
+    console.log('🔍 Buscando tema con slug:', slug);
+    
+    const updatedTheme = await SettingThemeModel.findOneAndUpdate(
+      { slug: slug },
+      { 
+        name: name,
+        slug: slug,
+        content: content
+      },
+      { 
+        new: true,
+        runValidators: true,
+        upsert: false
+      }
+    );
+    
+    if (!updatedTheme) {
+      console.log('❌ Tema no encontrado con slug:', slug);
+      return null;
+    }
+    
+    console.log('✅ Tema actualizado exitosamente');
+    return updatedTheme;
+  }
+
   async deleteTheme(name: string): Promise<boolean> {
     const result = await SettingThemeModel.deleteOne({ name });
     return result.deletedCount > 0;

--- a/src/presentation/controllers/SettingThemeController.ts
+++ b/src/presentation/controllers/SettingThemeController.ts
@@ -66,6 +66,58 @@ export class SettingThemeController {
     }
   }
 
+  // PUT /api/setting-theme/:slug
+  async updateTheme(req: Request, res: Response): Promise<void> {
+    try {
+      const { slug } = req.params;
+      const { name, content } = req.body;
+      
+      console.log('📥 Actualizando tema:', slug);
+      console.log('📦 Name recibido:', name);
+      console.log('📄 Content recibido:', content ? 'Sí' : 'No');
+      
+      if (!name) {
+        res.status(400).json({
+          success: false,
+          message: 'El campo "name" es requerido'
+        });
+        return;
+      }
+      
+      if (!content) {
+        res.status(400).json({
+          success: false,
+          message: 'El campo "content" es requerido'
+        });
+        return;
+      }
+
+      const theme = await this.settingThemeService.updateThemeBySlug({ slug, name, content });
+      
+      if (!theme) {
+        res.status(404).json({
+          success: false,
+          message: `Tema con slug "${slug}" no encontrado`
+        });
+        return;
+      }
+
+      console.log('✅ Tema actualizado exitosamente');
+      
+      res.json({
+        success: true,
+        message: 'Tema actualizado exitosamente',
+        data: theme
+      });
+    } catch (error: any) {
+      console.error('❌ Error al actualizar tema:', error);
+      res.status(500).json({
+        success: false,
+        message: error.message || 'Error al actualizar el tema'
+      });
+    }
+  }
+
   // DELETE /api/setting-theme/:name
   async deleteTheme(req: Request, res: Response): Promise<void> {
     try {

--- a/src/presentation/routes/setting-theme.routes.ts
+++ b/src/presentation/routes/setting-theme.routes.ts
@@ -7,14 +7,17 @@ const settingThemeController = new SettingThemeController();
 // Obtener todos los temas
 router.get('/', (req, res) => settingThemeController.getAllThemes(req, res));
 
-// Obtener tema por nombre
-router.get('/:name', (req, res) => settingThemeController.getThemeByName(req, res));
-
-// Obtener tema por slug
+// Obtener tema por slug (debe ir antes de /:name para evitar conflictos)
 router.get('/slug/:slug', (req, res) => settingThemeController.getThemeBySlug(req, res));
 
-// Crear/actualizar tema
+// Crear tema
 router.post('/', (req, res) => settingThemeController.saveTheme(req, res));
+
+// Actualizar tema por slug
+router.put('/:slug', (req, res) => settingThemeController.updateTheme(req, res));
+
+// Obtener tema por nombre
+router.get('/:name', (req, res) => settingThemeController.getThemeByName(req, res));
 
 // Eliminar tema
 router.delete('/:name', (req, res) => settingThemeController.deleteTheme(req, res));


### PR DESCRIPTION
- Added `updateThemeBySlug` method in `SettingThemeService` to update themes using their slug.
- Implemented corresponding method in `SettingThemeRepository` for database updates.
- Created `updateTheme` endpoint in `SettingThemeController` to handle PUT requests for theme updates.
- Updated routes to include the new update functionality for themes by slug.